### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "node SynologyAPI.js"
   },
   "repository": {
-    "git": "https://github.com/Clowning/Synology-NodeJS-API.git"
+    "type": "git",
+    "url": "git@github.com:Clowning/Synology-NodeJS-API.git"
   },
   "author": "Jonathan Roze",
   "license": "ISC",


### PR DESCRIPTION
The link to this respository is missing on the npmjs.com page. I think this should fix this for new releases.
